### PR TITLE
[Fix] REVOKE exception handling

### DIFF
--- a/lib/grantinee/engine/mysql.rb
+++ b/lib/grantinee/engine/mysql.rb
@@ -24,11 +24,7 @@ module Grantinee
 
       def revoke_permissions!(data)
         query = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM %{user};" % sanitize(data)
-        begin
-          run! query
-        rescue Exception => e
-          # MySQL freaks out when there are no grants yet...
-        end
+        run! query
       end
 
       def grant_permission!(data)


### PR DESCRIPTION
It seems MySQL doesn't actually break when user doesn't have grants. I suppose it was an issue with unsanitized queries or something.