### PR TITLE
fix(Security): CVE-2013-033

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    grantinee (0.3.3)
+    grantinee (0.4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    byebug (10.0.2)
+    byebug (11.1.3)
     diff-lcs (1.3)
     method_source (0.9.0)
-    mysql2 (0.5.1)
+    mysql2 (0.5.6)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
-    pg (1.0.0)
+    pg (1.5.6)
     powerpack (0.1.1)
     rainbow (3.0.0)
     rake (10.5.0)
@@ -45,7 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.5)
   byebug
   grantinee!
   method_source
@@ -56,4 +56,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.2
+   2.5.15

--- a/grantinee.gemspec
+++ b/grantinee.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.5"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "method_source"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Bundler in version < 2 allows attacker to inject arbitrary code via secondary Gem source

See: https://github.com/blinkist/grantinee/security/dependabot/6